### PR TITLE
Add actuator health endpoint for startup scripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ repositories {
 dependencies {
     // Spring Boot starters
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/src/main/java/com/accountabilityatlas/userservice/config/SecurityConfig.java
+++ b/src/main/java/com/accountabilityatlas/userservice/config/SecurityConfig.java
@@ -28,7 +28,9 @@ public class SecurityConfig {
         .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(
             auth ->
-                auth.requestMatchers("/auth/**")
+                auth.requestMatchers("/actuator/**")
+                    .permitAll()
+                    .requestMatchers("/auth/**")
                     .permitAll()
                     .requestMatchers("/users/**")
                     .authenticated()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,15 @@ spring:
     serialization:
       write-dates-as-timestamps: false
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+  endpoint:
+    health:
+      show-details: when-authorized
+
 logging:
   level:
     com.accountabilityatlas: DEBUG


### PR DESCRIPTION
## Summary
- Add `spring-boot-starter-actuator` dependency
- Configure management endpoints to expose health and info
- Permit `/actuator/**` endpoints without authentication

Closes #5

## Test plan
- [ ] `GET /actuator/health` returns 200 when service is running
- [ ] Health endpoint accessible without authentication
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)