### PR TITLE
fix: mock EventPublisher in integration tests

### DIFF
--- a/src/test/java/com/accountabilityatlas/userservice/integration/AuthIntegrationTest.java
+++ b/src/test/java/com/accountabilityatlas/userservice/integration/AuthIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.accountabilityatlas.userservice.event.EventPublisher;
 import com.jayway.jsonpath.JsonPath;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -47,6 +49,8 @@ class AuthIntegrationTest {
   }
 
   @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private EventPublisher eventPublisher;
 
   @Test
   void registerThenLogin_fullFlow() throws Exception {


### PR DESCRIPTION
## Summary

- Add `@MockitoBean EventPublisher` to `AuthIntegrationTest` to mock SQS event publishing

Fixes #15

## Test plan

- [x] Run `./gradlew check` - all tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)