### PR TITLE
chore: fix Foojay Toolchains link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ User identity and access management service for AccountabilityAtlas. Handles reg
 - **Docker Desktop** (for PostgreSQL and Redis)
 - **Git**
 
-JDK 21 is managed automatically by the Gradle wrapper via [Foojay Toolchain](https://github.com/gradle/foojay-toolchain) -- no manual JDK installation required.
+JDK 21 is managed automatically by the Gradle wrapper via [Foojay Toolchain](https://github.com/gradle/foojay-toolchains) -- no manual JDK installation required.
 
 ## Clone and Build
 


### PR DESCRIPTION
## Summary
Fixes #8 

## Changes
- Corrected the Foojay Toolchains plugin link in README.md
- Changed `foojay-toolchain` to `foojay-toolchains` (added missing 's')

## Testing
- Verified the new link points to the correct repository: https://github.com/gradle/foojay-toolchains