### PR TITLE
ci: publish test and coverage reports in CI

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  checks: write
+  pull-requests: write
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
@@ -15,5 +20,41 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+
       - name: Run checks
-        run: ./gradlew check
+        run: ./gradlew check jacocoTestReport
+
+      - name: Test Report
+        if: always()
+        uses: dorny/test-reporter@v2
+        with:
+          name: Test Results
+          path: build/test-results/test/*.xml
+          reporter: java-junit
+
+      - name: Coverage Report
+        if: always() && github.event_name == 'pull_request'
+        uses: madrapps/jacoco-report@v1.7.2
+        with:
+          paths: build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: '80'
+          min-coverage-changed-files: '80'
+          title: Coverage Report
+          update-comment: true
+
+      - name: Upload Test Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: build/reports/tests/test/
+          retention-days: 14
+
+      - name: Upload Coverage Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: build/reports/jacoco/test/html/
+          retention-days: 14


### PR DESCRIPTION
## Summary
- Add test result annotations via dorny/test-reporter
- Add JaCoCo coverage PR comments via madrapps/jacoco-report
- Upload HTML test and coverage reports as artifacts

Closes #34