### PR TITLE
fix: suppress SQS JavaType header for cross-service deserialization

### DIFF
--- a/src/main/java/com/accountabilityatlas/userservice/config/SqsConfig.java
+++ b/src/main/java/com/accountabilityatlas/userservice/config/SqsConfig.java
@@ -1,0 +1,60 @@
+package com.accountabilityatlas.userservice.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import io.awspring.cloud.sqs.support.converter.SqsMessagingMessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+/**
+ * SQS configuration for cross-service message handling.
+ *
+ * <p>By default, Spring Cloud AWS SQS adds a {@code JavaType} message attribute containing the
+ * fully-qualified class name of the payload. When producer and consumer services define the same
+ * event record in different packages, the consumer cannot load the producer's class, causing
+ * deserialization to fail with {@code ClassNotFoundException}.
+ *
+ * <p>This configuration disables the {@code JavaType} header on both the sending and receiving
+ * sides:
+ *
+ * <ul>
+ *   <li><b>Producer ({@link SqsTemplate})</b>: {@code setPayloadTypeHeaderValueFunction} returns
+ *       null, suppressing the header.
+ *   <li><b>Consumer ({@link SqsMessagingMessageConverter})</b>: {@code setPayloadTypeMapper}
+ *       returns null, forcing Jackson to use the {@code @SqsListener} method parameter type
+ *       instead.
+ * </ul>
+ */
+@Configuration
+public class SqsConfig {
+
+  /**
+   * Custom SqsTemplate that does not send the JavaType header. This prevents cross-service
+   * deserialization issues when event classes are defined in different packages.
+   */
+  @Bean
+  public SqsTemplate sqsTemplate(SqsAsyncClient sqsAsyncClient, ObjectMapper objectMapper) {
+    return SqsTemplate.builder()
+        .sqsAsyncClient(sqsAsyncClient)
+        .configureDefaultConverter(
+            converter -> {
+              converter.setObjectMapper(objectMapper);
+              converter.setPayloadTypeHeaderValueFunction(message -> null);
+            })
+        .build();
+  }
+
+  /**
+   * Custom SqsMessagingMessageConverter that ignores the JavaType header from incoming messages.
+   * This forces deserialization to use the @SqsListener method parameter type, which allows
+   * cross-service events with matching field structures but different package names.
+   */
+  @Bean
+  public SqsMessagingMessageConverter sqsMessagingMessageConverter(ObjectMapper objectMapper) {
+    SqsMessagingMessageConverter converter = new SqsMessagingMessageConverter();
+    converter.setObjectMapper(objectMapper);
+    converter.setPayloadTypeMapper(message -> null);
+    return converter;
+  }
+}

--- a/src/test/java/com/accountabilityatlas/userservice/config/SqsConfigTest.java
+++ b/src/test/java/com/accountabilityatlas/userservice/config/SqsConfigTest.java
@@ -1,0 +1,34 @@
+package com.accountabilityatlas.userservice.config;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import io.awspring.cloud.sqs.support.converter.SqsMessagingMessageConverter;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+class SqsConfigTest {
+
+  private final SqsConfig sqsConfig = new SqsConfig();
+
+  @Test
+  void sqsTemplate_createsTemplateWithoutPayloadTypeHeader() {
+    SqsAsyncClient sqsAsyncClient = mock(SqsAsyncClient.class);
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    SqsTemplate template = sqsConfig.sqsTemplate(sqsAsyncClient, objectMapper);
+
+    assertNotNull(template);
+  }
+
+  @Test
+  void sqsMessagingMessageConverter_createsConverterThatIgnoresPayloadTypeHeader() {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    SqsMessagingMessageConverter converter = sqsConfig.sqsMessagingMessageConverter(objectMapper);
+
+    assertNotNull(converter);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `SqsConfig` that customizes `SqsTemplate` to suppress the `JavaType` message attribute, preventing `ClassNotFoundException` when consumers in other services define the same event in a different package
- Includes consumer-side `SqsMessagingMessageConverter` bean that ignores `JavaType` headers on incoming messages, for forward compatibility when listeners are added
- Follows the same pattern already established in moderation-service

Closes #40

## Test plan
- [x] `SqsConfigTest` verifies both beans are created without error
- [x] `./gradlew check` passes (compilation, Spotless, tests, JaCoCo coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)