### PR TITLE
build: add SonarCloud integration

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -1,0 +1,28 @@
+name: SonarCloud
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  sonar:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Build, test, and analyze
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew test jacocoTestReport sonar

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'com.diffplug.spotless'
     id 'net.ltgt.errorprone'
     id 'jacoco'
+    id 'org.sonarqube'
     id 'org.openapi.generator'
 }
 
@@ -157,6 +158,16 @@ jacocoTestCoverageVerification {
 }
 
 check.dependsOn jacocoTestCoverageVerification
+
+// ---- SonarCloud ----
+sonar {
+    properties {
+        property 'sonar.projectKey', 'kelleyglenn_AcctAtlas-user-service'
+        property 'sonar.projectName', 'AcctAtlas-user-service'
+        property 'sonar.organization', 'kelleyglenn'
+        property 'sonar.host.url', 'https://sonarcloud.io'
+    }
+}
 
 // ---- Jib ----
 jib {

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,3 +29,6 @@ jacksonDatabindNullableVersion=0.2.8
 
 # Lombok
 lombokVersion=1.18.42
+
+# SonarQube
+sonarqubeVersion=7.2.2.6593

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,7 @@ pluginManagement {
         id 'com.diffplug.spotless' version "${spotlessVersion}"
         id 'net.ltgt.errorprone' version "${errorProneVersion}"
         id 'org.openapi.generator' version "${openApiGeneratorVersion}"
+        id 'org.sonarqube' version "${sonarqubeVersion}"
     }
 }
 


### PR DESCRIPTION
## Summary
- Add SonarCloud static analysis integration via the `org.sonarqube` Gradle plugin
- Add `.github/workflows/sonar.yaml` workflow for PR and master branch analysis
- Runs `test jacocoTestReport sonar` (separate from the existing `check` workflow)

## Prerequisites
The `sonar` workflow will fail until these manual steps are completed:
1. Import this repo as a SonarCloud project at [sonarcloud.io](https://sonarcloud.io) (org: `kelleyglenn`)
2. Add `SONAR_TOKEN` as a GitHub Actions secret

## Test plan
- [ ] Existing `check` workflow still passes (no build/test changes)
- [ ] After SONAR_TOKEN is configured, `sonar` workflow passes and decorates PRs

Generated with [Claude Code](https://claude.com/claude-code)